### PR TITLE
Fix loading environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 JULIA:=julia
 QUARTO:=quarto
 
-include _environment
-
 default: help
 
 render:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ make render
 ```
 or
 ```shell
-source _environment
+set -a && source _environment && set +a # Load the environment variables
 julia --project=@. -e 'import Pkg; Pkg.resolve();'
 quarto render
 ```


### PR DESCRIPTION
## Checklist
Thank you for contributing to Tutorials for Quantum Toolbox in `Julia`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to QuantumToolbox.jl](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] The (last update) `date` were modified for new or updated tutorials.
- [x] For new tutorials, a `Version Information` section was added at the end and displays the output of `versioninfo()`.
- [x] All tutorials were able to render locally by running: `make render`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
The previous implementation, wasn't exporting the environment variables. Quarto loads them automatically, but I changed the manual command in the README.