### PR TITLE
Fix errors for `QuantumToolbox.jl v0.31`

### DIFF
--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -10,4 +10,4 @@ jobs:
       - name: Checkout Actions Repository
         uses: actions/checkout@v4
       - name: Check spelling
-        uses: crate-ci/typos@v1.30.2
+        uses: crate-ci/typos@v1.32.0

--- a/QuantumToolbox.jl/time_evolution/kerr.qmd
+++ b/QuantumToolbox.jl/time_evolution/kerr.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Kerr nonlinearities"
 author: Li-Xun Cai
-date: 2025-02-08  # last update (keep this comment as a reminder)
+date: 2025-05-17  # last update (keep this comment as a reminder)
 
 engine: julia
 ---
@@ -126,10 +126,10 @@ Since we are considering unitary dynamics, i.e., no dissipation, the dynamics ar
 
 Note that if the keyword argument `e_ops` is not supplied to [`mesolve`](https://qutip.org/QuantumToolbox.jl/stable/resources/api#QuantumToolbox.sesolve), the returned `result` contains the state at each time point at field `states`. Consult the [user guide to `TimeEvolutionSol`](https://qutip.org/QuantumToolbox.jl/stable/users_guide/time_evolution/solution) for more details.
 ```{julia}
-ψ0 = coherent(N, 2.0)
+ρ0 = coherent_dm(N, 2.0)
 tlist = 0:0.01:(2*π / χ)
 
-result = mesolve(H, ψ0, tlist)
+result = mesolve(H, ρ0, tlist)
 ```
 
 We first check the expectation value dynamics of the number operator `n` with the two visualization functions we defined previously.

--- a/QuantumToolbox.jl/time_evolution/lowrank.qmd
+++ b/QuantumToolbox.jl/time_evolution/lowrank.qmd
@@ -1,7 +1,7 @@
 ---
 title: Low rank master equation
 author: Luca Gravina
-date: 2025-04-14  # last update (keep this comment as a reminder)
+date: 2025-05-17  # last update (keep this comment as a reminder)
 
 engine: julia
 ---
@@ -90,7 +90,7 @@ M = latt.N + 1; # Number of states in the LR basis
 Since we will take as initial state for our dynamics the pure state with all spins pointing up, the initial low-rank basis must include at least this state.
 
 ```{julia}
-ϕ = Vector{QuantumObject{KetQuantumObject,Dimensions{M - 1,NTuple{M - 1,Space}},Vector{ComplexF64}}}(undef, M)
+ϕ = Vector{QuantumObject{Ket,Dimensions{M - 1,NTuple{M - 1,Space}},Vector{ComplexF64}}}(undef, M)
 ϕ[1] = kron(fill(basis(2, 1), N_modes)...)
 ```
 
@@ -182,7 +182,7 @@ function f_entropy(p, z, B)
 
     mul!(C, z, sqrt(B))
     mul!(σ, C', C)
-    return entropy_vn(Qobj(Hermitian(σ), type=Operator), base=2)
+    return entropy_vn(Qobj(Hermitian(σ), type=Operator()), base=2)
 end;
 ```
 


### PR DESCRIPTION
## Checklist
Thank you for contributing to Tutorials for Quantum Toolbox in `Julia`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] The (last update) `date` were modified for new or updated tutorials.
- [x] For new tutorials, a `Version Information` section was added at the end and displays the output of `versioninfo()`.
- [x] All tutorials were able to render locally by running: `make render`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
As title