### PR TITLE
Add detailed authors informations

### DIFF
--- a/QuantumToolbox.jl/time_evolution/adiabatic.qmd
+++ b/QuantumToolbox.jl/time_evolution/adiabatic.qmd
@@ -1,7 +1,8 @@
 ---
 title: "Adiabatic sweep (with `QuantumObjectEvolution`)"
-author: Li-Xun Cai
 date: 2025-04-20  # last update (keep this comment as a reminder)
+author:
+    - ref: lixuncai
 
 engine: julia
 ---

--- a/QuantumToolbox.jl/time_evolution/lowrank.qmd
+++ b/QuantumToolbox.jl/time_evolution/lowrank.qmd
@@ -60,11 +60,11 @@ Jz = 1.0
 hx = 0.0
 γ = 1
 
-Sx = mapreduce(i->MultiSiteOperator(latt, i => sigmax()), +, 1:latt.N)
-Sy = mapreduce(i->MultiSiteOperator(latt, i => sigmay()), +, 1:latt.N)
-Sz = mapreduce(i->MultiSiteOperator(latt, i => sigmaz()), +, 1:latt.N)
+Sx = mapreduce(i->multisite_operator(latt, i => sigmax()), +, 1:latt.N)
+Sy = mapreduce(i->multisite_operator(latt, i => sigmay()), +, 1:latt.N)
+Sz = mapreduce(i->multisite_operator(latt, i => sigmaz()), +, 1:latt.N)
 
-SFxx = sum([MultiSiteOperator(latt, i => sigmax()) * MultiSiteOperator(latt, j => sigmax()) for i in 1:latt.N for j in 1:latt.N])
+SFxx = sum([multisite_operator(latt, i => sigmax()) * multisite_operator(latt, j => sigmax()) for i in 1:latt.N for j in 1:latt.N])
 
 H, c_ops = DissipativeIsing(Jx, Jy, Jz, hx, 0., 0., γ, latt; boundary_condition=:periodic_bc, order=1)
 e_ops = (Sx, Sy, Sz, SFxx)
@@ -99,13 +99,13 @@ The remaining `M-1` states are taken as those with minimal Hamming distance from
 i = 1
 for j in 1:N_modes
     global i += 1
-    i <= M && (ϕ[i] = MultiSiteOperator(latt, j=>sigmap()) * ϕ[1])
+    i <= M && (ϕ[i] = multisite_operator(latt, j=>sigmap()) * ϕ[1])
 end
 
 for k in 1:N_modes-1
     for l in k+1:N_modes
         global i += 1
-        i <= M && (ϕ[i] = MultiSiteOperator(latt, k=>sigmap(), l=>sigmap()) * ϕ[1])
+        i <= M && (ϕ[i] = multisite_operator(latt, k=>sigmap(), l=>sigmap()) * ϕ[1])
     end
 end
 ```

--- a/_authors.yml
+++ b/_authors.yml
@@ -1,0 +1,43 @@
+author:
+  - id: albertomercurio
+    name: Alberto Mercurio
+    orcid: 0000-0001-7814-1936
+    email: alberto.mercurio@epfl.ch
+    affiliations:
+      - ref: 1
+
+  - id: yitehuang
+    name: Yi-Te Huang
+    orcid: 0000-0002-2520-8348
+    email: yitehuang.tw@gmail.com
+    affiliations:
+      - ref: 2
+      - ref: 3
+
+  - id: lixuncai
+    name: Li-Xun Cai
+    orcid: 0009-0006-7644-5200
+    email: cailixun23@gmail.com
+    affiliations:
+      - ref: 2
+      - ref: 3
+
+affiliations:
+  - id: 1
+    name: École Polytechnique Fédérale de Lausanne (EPFL)
+    address: Rte Cantonale
+    city: Lausanne
+    state: Switzerland
+    postal-code: 1015
+
+  - id: 2
+    name: National Cheng Kung University
+    city: Tainan
+    state: Taiwan
+    postal-code: 701401
+
+  - id: 3
+    name: Center for Quantum Frontiers of Research and Technology (QFort)
+    city: Tainan
+    state: Taiwan
+    postal-code: 701401

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -9,6 +9,9 @@ project:
     - "!CODE_OF_CONDUCT.md"    # ignore
     - "!tutorial_template.qmd" # ignore
 
+metadata-files:
+  - _authors.yml
+
 website:
   title: Tutorials for Quantum Toolbox in Julia
   site-url: https://qutip.org/qutip-julia-tutorials/


### PR DESCRIPTION
## Checklist
Thank you for contributing to Tutorials for Quantum Toolbox in `Julia`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [ ] The (last update) `date` were modified for new or updated tutorials.
- [x] For new tutorials, a `Version Information` section was added at the end and displays the output of `versioninfo()`.
- [ ] All tutorials were able to render locally by running: `make render`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
This PR tries to add detailed informations about the authors, like affiliations, orcid or email. In order to avoid to repeat many lines of `yaml` codes every time, I'm looking for some automatic way to handle authors. It is not yet well supported, as also discussed in other issues

- https://github.com/quarto-dev/quarto-cli/discussions/12765
- https://github.com/quarto-dev/quarto-cli/discussions/12412
- https://github.com/quarto-dev/quarto-cli/discussions/8097