### PR TITLE
Make julia engine global

### DIFF
--- a/HierarchicalEOM.jl/SIAM.qmd
+++ b/HierarchicalEOM.jl/SIAM.qmd
@@ -1,9 +1,7 @@
 ---
 title: "Single-impurity Anderson model"
 author: Yi-Te Huang
-date: 2025-01-14  # last update (keep this comment as a reminder)
-
-engine: julia
+date: 2025-05-22  # last update (keep this comment as a reminder)
 ---
 
 ## Introduction

--- a/HierarchicalEOM.jl/cavityQED.qmd
+++ b/HierarchicalEOM.jl/cavityQED.qmd
@@ -1,9 +1,7 @@
 ---
 title: "Cavity QED system"
 author: Shen-Liang Yang, Yi-Te Huang
-date: 2025-01-13  # last update (keep this comment as a reminder)
-
-engine: julia
+date: 2025-05-22  # last update (keep this comment as a reminder)
 ---
 
 ## Introduction

--- a/HierarchicalEOM.jl/dynamical_decoupling.qmd
+++ b/HierarchicalEOM.jl/dynamical_decoupling.qmd
@@ -1,9 +1,7 @@
 ---
 title: "Driven systems and dynamical decoupling"
 author: Yi-Te Huang
-date: 2025-01-14  # last update (keep this comment as a reminder)
-
-engine: julia
+date: 2025-05-22  # last update (keep this comment as a reminder)
 ---
 
 Inspirations taken from an example in QuTiP-BoFiN article [@QuTiP-BoFiN2023].

--- a/HierarchicalEOM.jl/electronic_current.qmd
+++ b/HierarchicalEOM.jl/electronic_current.qmd
@@ -1,9 +1,7 @@
 ---
 title: "Electronic Current"
 author: Yi-Te Huang
-date: 2025-01-14  # last update (keep this comment as a reminder)
-
-engine: julia
+date: 2025-05-22  # last update (keep this comment as a reminder)
 ---
 
 Inspirations taken from [qutip documentation](https://qutip.org/documentation.html).

--- a/QuantumToolbox.jl/time_evolution/Dicke.qmd
+++ b/QuantumToolbox.jl/time_evolution/Dicke.qmd
@@ -1,9 +1,7 @@
 ---
 title: "The Dicke Model"
 author: Li-Xun Cai
-date: 2025-03-11  # last update (keep this comment as a reminder)
-
-engine: julia
+date: 2025-05-22  # last update (keep this comment as a reminder)
 ---
 
 Inspirations taken from [this QuTiP tutorial](https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/lectures/Lecture-3A-Dicke-model.ipynb) by J. R. Johansson.

--- a/QuantumToolbox.jl/time_evolution/adiabatic.qmd
+++ b/QuantumToolbox.jl/time_evolution/adiabatic.qmd
@@ -1,9 +1,7 @@
 ---
 title: "Adiabatic sweep (with `QuantumObjectEvolution`)"
 author: Li-Xun Cai
-date: 2025-04-20  # last update (keep this comment as a reminder)
-
-engine: julia
+date: 2025-05-22  # last update (keep this comment as a reminder)
 ---
 
 Inspirations taken from [the QuTiP tutorial](https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/lectures/Lecture-8-Adiabatic-quantum-computing.ipynb) by J. R. Johansson.

--- a/QuantumToolbox.jl/time_evolution/fluorescence.qmd
+++ b/QuantumToolbox.jl/time_evolution/fluorescence.qmd
@@ -1,9 +1,7 @@
 ---
 title: "Resonance fluorescence"
 author: Li-Xun Cai
-date: 2025-01-27 # last update (keep this comment as a reminder)
-
-engine: julia
+date: 2025-05-22 # last update (keep this comment as a reminder)
 ---
 
 Inspirations taken from [this QuTiP tutorial](https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/lectures/Lecture-13-Resonance-flourescence.ipynb) by J. R. Johansson.

--- a/QuantumToolbox.jl/time_evolution/kerr.qmd
+++ b/QuantumToolbox.jl/time_evolution/kerr.qmd
@@ -1,9 +1,7 @@
 ---
 title: "Kerr nonlinearities"
 author: Li-Xun Cai
-date: 2025-05-17  # last update (keep this comment as a reminder)
-
-engine: julia
+date: 2025-05-22  # last update (keep this comment as a reminder)
 ---
 
 Inspirations taken from [this QuTiP tutorial](https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/lectures/Lecture-14-Kerr-nonlinearities.ipynb) by J. R. Johansson.

--- a/QuantumToolbox.jl/time_evolution/lowrank.qmd
+++ b/QuantumToolbox.jl/time_evolution/lowrank.qmd
@@ -1,9 +1,7 @@
 ---
 title: Low rank master equation
 author: Luca Gravina
-date: 2025-05-17  # last update (keep this comment as a reminder)
-
-engine: julia
+date: 2025-05-22  # last update (keep this comment as a reminder)
 ---
 
 ## Introduction

--- a/QuantumToolbox.jl/time_evolution/rabi.qmd
+++ b/QuantumToolbox.jl/time_evolution/rabi.qmd
@@ -1,11 +1,9 @@
 ---
 title: "Vacuum Rabi oscillation"
 author: Li-Xun Cai
-date: 2025-01-17 # last update (keep this comment as a reminder)
-
-engine: julia
+date: 2025-05-22 # last update (keep this comment as a reminder)
 ---
-
+    
 Inspirations taken from [this QuTiP tutorial](https://nbviewer.org/urls/qutip.org/qutip-tutorials/tutorials-v5/time-evolution/004_rabi-oscillations.ipynb) by J.R. Johansson, P.D. Nation, and C. Staufenbiel
 
 In this notebook, the usage of `QuantumToolbox.sesolve` and `QuantumToolbox.mesolve` will be demonstrated with Jaynes-Cummings model (JC model) to observe Rabi oscillations in the isolated case and the dissipative case. In the dissipative case, a bosonic interacts with the cavity and the two-level atom in the JC model.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -43,7 +43,9 @@ website:
       - icon: github
         href:  https://github.com/qutip/qutip-julia-tutorials
 
-bibliography: bibliography.bib  
+bibliography: bibliography.bib
+
+engines: ['julia']
 
 # default format for all files
 format:

--- a/tutorial_template.qmd
+++ b/tutorial_template.qmd
@@ -2,8 +2,6 @@
 title: "Tutorial Template"
 author: Author(s) Name
 date: YYYY-MM-DD  # last update (keep this comment as a reminder)
-
-engine: julia
 ---
 
 Inspirations taken from somewhere by someone. (or some preface)


### PR DESCRIPTION
## Checklist
Thank you for contributing to Tutorials for Quantum Toolbox in `Julia`! Please make sure you have finished the following tasks before opening the PR.

- [x] Please read [Contributing to Quantum Toolbox in Julia](https://qutip.org/QuantumToolbox.jl/stable/resources/contributing).
- [x] The (last update) `date` were modified for new or updated tutorials.
- [x] For new tutorials, a `Version Information` section was added at the end and displays the output of `versioninfo()`.
- [x] All tutorials were able to render locally by running: `make render`.

Request for a review after you have completed all the tasks. If you have not finished them all, you can also open a [Draft Pull Request](https://github.blog/2019-02-14-introducing-draft-pull-requests/) to let the others know this on-going work.

## Description
With the new versions of quarto it is possible to declare the `julia` engine globally in the project file. This avoids to define it on every notebook.